### PR TITLE
feat: 회원가입 구현 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,10 @@ java {
     }
 }
 
+springBoot {
+    mainClass = project.group.toString()
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
@@ -8,6 +8,9 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 import taegeuni.github.project_justrun.security.JwtAuthenticationFilter
 
 @Configuration
@@ -15,6 +18,18 @@ import taegeuni.github.project_justrun.security.JwtAuthenticationFilter
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter
 ) {
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf("http://localhost:3000")
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
 
     @Bean
     fun passwordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
@@ -22,11 +37,13 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .csrf { it.disable() }
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers(
                         "/api/auth/login",
+                        "/api/auth/register",
                         "/api/ranking/top",
                         "/images/**"
                     ).permitAll()

--- a/src/main/kotlin/taegeuni/github/project_justrun/controller/AuthController.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/controller/AuthController.kt
@@ -27,7 +27,12 @@ class AuthController(
         }
 
         val latestStudent = userRepository.findTopByStudentNumberIsNotNullAndUserTypeOrderByUserIdDesc()
-        val studentNumber = LocalDate.now().year.toString() + String.format("%04d", latestStudent?.studentNumber?.drop(4)?.toInt()?.plus(1) ?: 1)
+
+        val latestStudentEntranceYear = latestStudent?.studentNumber?.take(4)
+        val currentYear = LocalDate.now().year.toString()
+        val isFirstStudentOfTheYear =  latestStudentEntranceYear != null && latestStudentEntranceYear != currentYear
+        val lastFourDigits = if (isFirstStudentOfTheYear) 1 else latestStudent?.studentNumber?.drop(4)?.toInt()?.plus(1) ?: 1
+        val studentNumber = currentYear + String.format("%04d",  lastFourDigits)
 
         val newUser = User(
             username = body.username,

--- a/src/main/kotlin/taegeuni/github/project_justrun/controller/AuthController.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/controller/AuthController.kt
@@ -4,8 +4,13 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import taegeuni.github.project_justrun.dto.CommonResponse
+import taegeuni.github.project_justrun.dto.ErrorResponse
+import taegeuni.github.project_justrun.entity.User
+import taegeuni.github.project_justrun.entity.UserType
 import taegeuni.github.project_justrun.repository.UserRepository
 import taegeuni.github.project_justrun.util.JwtUtil
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/auth")
@@ -14,11 +19,33 @@ class AuthController(
     private val jwtUtil: JwtUtil,
     private val passwordEncoder: BCryptPasswordEncoder
 ) {
+    @PostMapping("/register")
+    fun register(@RequestBody body: RegisterRequestDto): ResponseEntity<*> {
+        val user = userRepository.findByUsernameOrEmail(body.username, body.email)
+        if (user != null) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse("User already exists"))
+        }
+
+        val latestStudent = userRepository.findTopByStudentNumberIsNotNullAndUserTypeOrderByUserIdDesc()
+        val studentNumber = LocalDate.now().year.toString() + String.format("%04d", latestStudent?.studentNumber?.drop(4)?.toInt()?.plus(1) ?: 1)
+
+        val newUser = User(
+            username = body.username,
+            email = body.email,
+            password = passwordEncoder.encode(body.password),
+            name = body.name,
+            userType = UserType.student,
+            studentNumber = studentNumber
+        )
+        userRepository.save(newUser)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse("User registered successfully"))
+    }
 
     @PostMapping("/login")
     fun login(@RequestBody request: LoginRequest): ResponseEntity<Any> {
         val user = userRepository.findByUsername(request.username)
-            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password")
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse("Invalid username or password"))
 
         return if (passwordEncoder.matches(request.password, user.password)) {
             val token = jwtUtil.generateToken(user.userId) // 수정된 부분
@@ -36,12 +63,19 @@ class AuthController(
             )
             ResponseEntity.ok(response)
         } else {
-            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password")
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse("Invalid username or password"))
         }
     }
 }
 
 data class LoginRequest(val username: String, val password: String)
+
+data class RegisterRequestDto(
+    val username: String,
+    val password: String,
+    val email: String,
+    val name: String,
+)
 
 data class LoginResponse(
     val message: String,

--- a/src/main/kotlin/taegeuni/github/project_justrun/dto/CommonResponse.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/dto/CommonResponse.kt
@@ -1,0 +1,5 @@
+package taegeuni.github.project_justrun.dto
+
+data class CommonResponse(
+    val message: String,
+)

--- a/src/main/kotlin/taegeuni/github/project_justrun/repository/UserRepository.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/repository/UserRepository.kt
@@ -17,4 +17,8 @@ interface UserRepository : JpaRepository<User, Int> {
 
     @Query("SELECT COUNT(u) + 1 FROM User u WHERE u.rankingPoints > :rankingPoints AND u.userType = 'student'")
     fun findUserRank(@Param("rankingPoints") rankingPoints: Int): Long
+
+    fun findByUsernameOrEmail(username: String, password: String): User?
+
+    fun findTopByStudentNumberIsNotNullAndUserTypeOrderByUserIdDesc(userType: UserType = UserType.student): User?
 }


### PR DESCRIPTION
회원가입 엔드포인트 구현 완료하였습니다. API 엔드포인트는 POST /api/auth/register이며, Notion과는 Request Body의 스펙이 다릅니다.

data class RegisterRequestDto(
    val username: String,
    val password: String,
    val email: String,
    val name: String,
)

studentNumber의 경우 DB에서 가장 Index가 높은 UserType이 student인 entity를 조회, 해당 학생의 학번 중 앞 4자리를 추출하여 현재 년도와 비교하여 다음 분기를 통해 자동 결정합니다.

1. 학생이 DB 전체에서 최초로 등록한 학생: 학번이 해당 년도 + 0001로 결정됩니다.
2. 학생이 이번 년도에 최초로 등록한 학생: 1과 동일합니다.
3. 학생이 이번 년도에 최초로 등록한 학생이 아닐 경우: 해당 년도 + 마지막으로 등록된 학생의 학번 끝 4자리 + 1이 됩니다.

userType의 경우 기본 값을 student로 사용하도록 설정하였기에 Request Body에 일단은 포함하지 않았습니다.

이후 의사결정이 필요한 부분 설명 드리겠습니다.

1. 유저가 가입을 성공했을 때, 어떠한 과목을 수강하는 지 백엔드에서 아직 처리하지 않았습니다. 가장 대표적인 방법으로는 현존하는 모든 과목을 수강한다고 가정하여 enroll 테이블에 1대 다 연결을 하는 것입니다. 이 부분은 독단적으로 구현할 수 없기에 아직 구현하지 않았습니다.

해당 부분들 숙지하여 주시면 감사하겠습니다.

+ 추가적으로, CORS 옵션을 설정하여 http://localhost:3000에서 오는 요청에 대한 Strict-Origin 설정을 해제하였습니다. 참고 부탁드립니다. 해당 코드는 SecurityConfig.kt에 추가하였습니다.