### PR TITLE
feat: 과제 제출 시 파일 업로드 구현 완료 (toss to TaeGeuni)

### DIFF
--- a/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
@@ -45,6 +45,7 @@ class SecurityConfig(
                         "/api/auth/login",
                         "/api/auth/register",
                         "/api/ranking/top",
+                        "/api/assignments/{assignmentId}/submit",
                         "/images/**"
                     ).permitAll()
                     .anyRequest().authenticated()

--- a/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/config/SecurityConfig.kt
@@ -45,7 +45,6 @@ class SecurityConfig(
                         "/api/auth/login",
                         "/api/auth/register",
                         "/api/ranking/top",
-                        "/api/assignments/{assignmentId}/submit",
                         "/images/**"
                     ).permitAll()
                     .anyRequest().authenticated()

--- a/src/main/kotlin/taegeuni/github/project_justrun/controller/AssignmentController.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/controller/AssignmentController.kt
@@ -31,7 +31,6 @@ class AssignmentController(
         @PathVariable assignmentId: Int,
         @RequestHeader("Authorization") token: String
     ): ResponseEntity<*> {
-        print(token)
         val userId = jwtUtil.getUserIdFromToken(token.substring(7))
         val assignment = assignmentService.getAssignment(userId, assignmentId)
             ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse("Assignment not found"))

--- a/src/main/kotlin/taegeuni/github/project_justrun/controller/AssignmentController.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/controller/AssignmentController.kt
@@ -4,6 +4,8 @@ import AssignmentDto
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+import taegeuni.github.project_justrun.dto.AssignmentSubmitResponse
 import taegeuni.github.project_justrun.dto.ErrorResponse
 import taegeuni.github.project_justrun.service.AssignmentService
 import taegeuni.github.project_justrun.util.JwtUtil
@@ -14,7 +16,6 @@ class AssignmentController(
     private val assignmentService: AssignmentService,
     private val jwtUtil: JwtUtil
 ) {
-
     @GetMapping("/courses/{courseId}/assignments")
     fun getAssignmentList(
         @PathVariable courseId: Int,
@@ -30,6 +31,7 @@ class AssignmentController(
         @PathVariable assignmentId: Int,
         @RequestHeader("Authorization") token: String
     ): ResponseEntity<*> {
+        print(token)
         val userId = jwtUtil.getUserIdFromToken(token.substring(7))
         val assignment = assignmentService.getAssignment(userId, assignmentId)
             ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse("Assignment not found"))
@@ -44,5 +46,21 @@ class AssignmentController(
             courseId = assignment.course.courseId // Lazy Loading 방지
         )
         return ResponseEntity.ok(assignmentDto)
+    }
+
+    @PostMapping("/assignments/{assignmentId}/submit")
+    fun submitAssignment(
+        @RequestParam("file") file: MultipartFile?,
+        @RequestParam("content") content: String?,
+        @PathVariable assignmentId: Int,
+        @RequestHeader("Authorization") token: String
+    ): ResponseEntity<*> {
+        val userId = jwtUtil.getUserIdFromToken(token.substring(7))
+        assignmentService.submitAssignment(file, content, assignmentId, userId)
+        return ResponseEntity.ok(
+            AssignmentSubmitResponse(
+                "assignment successfully submitted"
+            )
+        )
     }
 }

--- a/src/main/kotlin/taegeuni/github/project_justrun/dto/AssignmentSubmitResponse.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/dto/AssignmentSubmitResponse.kt
@@ -1,0 +1,5 @@
+package taegeuni.github.project_justrun.dto
+
+data class AssignmentSubmitResponse(
+    val message: String
+)

--- a/src/main/kotlin/taegeuni/github/project_justrun/exception/BadRequestException.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/exception/BadRequestException.kt
@@ -1,0 +1,7 @@
+package taegeuni.github.project_justrun.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class BadRequestException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/taegeuni/github/project_justrun/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/exception/GlobalExceptionHandler.kt
@@ -15,6 +15,12 @@ class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse)
     }
 
+    @ExceptionHandler(BadRequestException::class)
+    fun handleBadRequestException(e: BadRequestException): ResponseEntity<ErrorResponse> {
+        val errorResponse = ErrorResponse(message = e.message ?: "잘못된 요청입니다.")
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse)
+    }
+
     @ExceptionHandler(IllegalAccessException::class)
     fun handleIllegalAccessException(ex: IllegalAccessException): ResponseEntity<ErrorResponse> {
         val errorResponse = ErrorResponse(message = ex.message ?: "접근이 거부되었습니다.")
@@ -39,7 +45,6 @@ class GlobalExceptionHandler {
         val errorResponse = ErrorResponse(message = ex.message ?: "서버 에러가 발생했습니다.")
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse)
     }
-
 
 
 }

--- a/src/main/kotlin/taegeuni/github/project_justrun/service/AssignmentService.kt
+++ b/src/main/kotlin/taegeuni/github/project_justrun/service/AssignmentService.kt
@@ -1,11 +1,25 @@
 package taegeuni.github.project_justrun.service
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import taegeuni.github.project_justrun.dto.*
-import taegeuni.github.project_justrun.entity.*
+import org.springframework.web.multipart.MultipartFile
+import taegeuni.github.project_justrun.dto.AssignmentListResponseItemForProfessor
+import taegeuni.github.project_justrun.dto.AssignmentListResponseItemForStudent
+import taegeuni.github.project_justrun.entity.Assignment
+import taegeuni.github.project_justrun.entity.Course
+import taegeuni.github.project_justrun.entity.User
+import taegeuni.github.project_justrun.entity.UserType
+import taegeuni.github.project_justrun.exception.BadRequestException
 import taegeuni.github.project_justrun.exception.ForbiddenException
 import taegeuni.github.project_justrun.repository.*
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Service
 class AssignmentService(
@@ -15,6 +29,10 @@ class AssignmentService(
     private val userRepository: UserRepository,
     private val enrollmentRepository: EnrollmentRepository
 ) {
+    @Value("\${app.upload.dir}")
+    private val uploadPath: String = "./files"
+
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
     fun getAssignmentList(userId: Int, courseId: Int): List<Any> {
@@ -60,7 +78,10 @@ class AssignmentService(
     }
 
 
-    private fun getAssignmentListForProfessor(user: User, course: Course): List<AssignmentListResponseItemForProfessor> {
+    private fun getAssignmentListForProfessor(
+        user: User,
+        course: Course
+    ): List<AssignmentListResponseItemForProfessor> {
         // 1. 사용자가 해당 강의의 교수인지 확인
         if (course.professor.userId != user.userId) {
             throw IllegalAccessException("해당 강의에 대한 접근 권한이 없습니다.")
@@ -81,6 +102,44 @@ class AssignmentService(
 
     @Transactional(readOnly = true)
     fun getAssignment(userId: Int, assignmentId: Int): Assignment? {
+        val assignment = findValidAssignmentByUserIdAndAssignmentId(userId, assignmentId)
+        return assignment
+    }
+
+    fun submitAssignment(file: MultipartFile?, content: String?, assignmentId: Int, userId: Int) {
+        if (file == null && content == null) {
+            throw BadRequestException("파일과 본문 중 하나 이상의 필드는 존재해야 합니다.")
+        }
+        val user = userRepository.findById(userId)
+            .orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다.") }
+
+        val assignment = findValidAssignmentByUserIdAndAssignmentId(userId, assignmentId)
+
+        if (file != null) {
+            val path = Paths.get(uploadPath, assignment.course.courseName)
+            val currentDateTime = LocalDateTime.now()
+            val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:HH:mm:ss")
+            val formattedDateTime = currentDateTime.format(formatter)
+            val filename = user.name + "_" + formattedDateTime + "_" + file.originalFilename
+
+            Files.createDirectories(path)
+
+            try {
+                val savedFile = File(path.toRealPath().toString(), filename)
+                file.transferTo(savedFile)
+            } catch (e: Exception) {
+                logger.error("Error while transfer to $filename", e)
+                throw Error("Error on saving file")
+            }
+        }
+
+        //TODO: 과제 실제로 제출하는 로직 작성
+    }
+
+    private fun findValidAssignmentByUserIdAndAssignmentId(
+        userId: Int,
+        assignmentId: Int
+    ): Assignment {
         val user = userRepository.findById(userId)
             .orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다.") }
 
@@ -89,14 +148,15 @@ class AssignmentService(
 
         val enrollments = enrollmentRepository.findAllByUserUserId(user.userId)
 
-        val isPermitted =  enrollments.any {
+        val isPermitted = enrollments.any {
             it.course.courseId == assignment.course.courseId
         }
 
         if (!isPermitted) {
             throw ForbiddenException("권한이 없습니다.")
         }
-
         return assignment
     }
+
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,6 +19,7 @@ jwt.expirationTime=3600000
 logging.level.org.springframework.security=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-
-
+app.upload.dir=./files
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=15MB
 server.port=8080


### PR DESCRIPTION
1. 과제 제출 엔드포인트 생성하였습니다. 엔드포인트는 다음과 같습니다:

POST /api/assignments/{assignmentId}/submit

해당 엔드포인트의 스펙은 다음과 같습니다.

Content-Type: multipart/form-data
field:
- file: 실제 파일이 들어가는 필드입니다.(Optional)
- content: 과제 본문이 들어가는 필드입니다.(Optional)

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/0d634eb3-aa74-44bf-83f5-f59917907d0e">


현재로서의 구현 기능은 다음과 같습니다.

사용자가 파일을 요청하였을 때, 해당 파일을 다음과 같은 형식으로 저장합니다.
uploadDir(default: "./files") + 과목 이름 + 원래 파일 이름

이 이후 실제 과제 제출 로직은 시간 관계상 구현하기 힘들기에 toss 하겠습니다. 나머지 구현을 부탁드립니다.

추가: 현재 application.properties 파일에 3가지 속성이 추가되었습니다.

app.upload.dir=./files
spring.servlet.multipart.max-file-size=10MB
spring.servlet.multipart.max-request-size=15MB

다운로드 경로, 파일의 최대 사이즈, 파일을 포함한 request 요청 패킷의 최대 사이즈를 설정해 놓았으니, 프로젝트 사양에 맞게 바꾸시면 됩니다.